### PR TITLE
Replace ls with find for better filename support

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -6,7 +6,7 @@ shopt -s nullglob
 function provision() {
   set +e
   pushd "$1" > /dev/null
-  for f in $(ls "$1"/*.json); do
+  find . -maxdepth 1 -name "*.json" -type f -printf "%f\n" | while read f; do
     p="$1/${f%.json}"
     echo "Provisioning $p"
     curl \


### PR DESCRIPTION
This modification allows for better filename support - namely whitespace becomes a non-issue.

For example, the current code fails against

    data/ldap/groups/Some Group.json

Where the replacement command will handle the above scenario.

Also, in case someone on the internets is searching around for how to do whitespaced Active Directory group names via this method, this is what you need:

    vi data/ldap/groups/Some%20Group.json

Add your policies per usual. Had to do some tcpdumping to figure that one out.