### PR TITLE
fixed typoe in for loop (ls globbing)

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -6,7 +6,7 @@ shopt -s nullglob
 function provision() {
   set +e
   pushd "$1" > /dev/null
-  for f in $(ls "$1"/*.json); do
+  for f in $(ls *.json); do
     p="$1/${f%.json}"
     echo "Provisioning $p"
     curl \


### PR DESCRIPTION
script was trying to ls a directory it had already cd'd into.